### PR TITLE
fix: fixing duplicate fetches and loading behavior issue

### DIFF
--- a/sinecloud/src/Components/Feed/Feed.js
+++ b/sinecloud/src/Components/Feed/Feed.js
@@ -31,8 +31,12 @@ const Feed = () => {
   const elementsRef = useRef([]);
   const limit = 5;
   const lastTrackRef = useRef();
+  const [isFetchingData, setIsFetchingData] = useState(false);
 
   const fetchTracks = () => {
+    if (isFetchingData) return;
+    setIsFetchingData(true);
+
     fetch(
       `http://localhost:4000/api/soundcloud?offset=${offset}&limit=${limit}`
     )
@@ -43,11 +47,18 @@ const Feed = () => {
       })
       .then((data) => {
         console.log(data);
-        setUsersData((oldData) => [...oldData, ...data.message]);
+        setUsersData((oldData) => {
+          const newData = data.message.filter(
+            (item) => !oldData.some((oldItem) => oldItem.track.id === item.track.id)
+          );
+          return [...oldData, ...newData];
+        });
         setOffset((oldOffset) => oldOffset + limit);
+        setIsFetchingData(false); // Allow the next fetch when the current one is completed
       })
       .catch((error) => {
         console.error(error);
+        setIsFetchingData(false); // Make sure to reset the flag even if there's an error
       });
   };
 


### PR DESCRIPTION
## Issue

[[Link to the issue]](https://github.com/heckspoiler/sinecloud/issues/1)

## Problem

The current behavior in our application is causing duplicate fetches and presenting strange loading behavior. Here's what's happening:

The backend fetches several mixes, and there are no duplicates in the backend array.
However, on the frontend, the displayed mixes are showing duplicates.
Additionally, the loading behavior of the application is acting erratically, making the user experience confusing.

## Solution

The backend is fetching data from SoundCloud and returning mixes to the frontend in sets of 5. The frontend then appends these mixes to the usersData state, which may lead to duplicates being displayed.

The reason for duplicates is the way the usersData state is managed. Since the state is being updated with the previous data, setUsersData((oldData) => [...oldData, ...data.message]);, it might lead to duplicates if any mixes in data.message are already present in oldData.

To resolve this issue, I added  a step to filter out duplicates before updating the state with the new data.


## Screen Record


[Sinecloud.webm](https://github.com/heckspoiler/sinecloud/assets/98264322/320ec98b-f636-4b6e-a508-406cef0a23a5)

## Checklist

- [x] I have tested my changes thoroughly.
- [x] My code follows the project's coding style and conventions.
- [x] I have added appropriate comments to the code for better understanding.

